### PR TITLE
Rack 2.0 deprecated string references

### DIFF
--- a/lib/rack/maintenance_mode/railtie.rb
+++ b/lib/rack/maintenance_mode/railtie.rb
@@ -15,7 +15,7 @@ module Rack
       config.maintenance_mode = ActiveSupport::OrderedOptions.new
 
       initializer 'rack-maintenance_mode.insert_middleware' do |app|
-        app.config.middleware.use 'Rack::MaintenanceMode::Middleware', config.maintenance_mode
+        app.config.middleware.use Rack::MaintenanceMode::Middleware, config.maintenance_mode
       end
     end
   end


### PR DESCRIPTION
DEPRECATION WARNING: Passing strings or symbols to the middleware builder is deprecated, please change
them to actual class references.  For example:

  "Rack::MaintenanceMode::Middleware" => Rack::MaintenanceMode::Middleware

I think this is fairly backward-compatible assuming that Rack::MaintenanceMode::Middleware is loaded first.
