### PR TITLE
Fix Rack 2 deprecation warnings

### DIFF
--- a/lib/rack/maintenance_mode/railtie.rb
+++ b/lib/rack/maintenance_mode/railtie.rb
@@ -15,7 +15,7 @@ module Rack
       config.maintenance_mode = ActiveSupport::OrderedOptions.new
 
       initializer 'rack-maintenance_mode.insert_middleware' do |app|
-        app.config.middleware.use 'Rack::MaintenanceMode::Middleware', config.maintenance_mode
+        app.config.middleware.use Rack::MaintenanceMode::Middleware, config.maintenance_mode
       end
     end
   end

--- a/spec/maintenance_spec.rb
+++ b/spec/maintenance_spec.rb
@@ -10,17 +10,17 @@ describe Rack::MaintenanceMode do
     maintain_env "MAINTENANCE"
 
     context "with ENV[\"MAINTENANCE\"] enabled" do
-      it 'should be in maintenance mode' do
+      it 'is in maintenance mode' do
         ['t', 'true', 'enable', 'enabled', 'y', 'yes', "yes\n"].each do |setting|
           ENV['MAINTENANCE'] = setting
-          app.call({}).should be_a_maintenance_response, "Failed with #{setting.inspect}"
+          expect(app.call({})).to be_a_maintenance_response, "Failed with #{setting.inspect}"
         end
       end
 
-      it 'should contain the default response' do
+      it 'contains the default response' do
         ['t', 'true', 'enable', 'enabled', 'y', 'yes', "yes\n"].each do |setting|
           ENV['MAINTENANCE'] = setting
-          app.call({}).should contain_the_default_response
+          expect(app.call({})).to contain_the_default_response
         end
       end
     end
@@ -28,20 +28,20 @@ describe Rack::MaintenanceMode do
     context 'with ENV["MAINTENANCE"] disabled' do
       before(:each) { ENV['MAINTENANCE'] = 'false' }
 
-      it { should_not be_a_maintenance_response }
+      it { is_expected.to_not be_a_maintenance_response }
 
-      it 'should return the response content' do
-        subject.last.should == ['Ok']
+      it 'returns the response content' do
+        expect(subject.last).to eq ['Ok']
       end
     end
 
     context 'with ENV["MAINTENANCE"] being nil' do
       before(:each) { ENV['MAINTENANCE'] = nil }
 
-      it { should_not be_a_maintenance_response }
+      it { is_expected.to_not be_a_maintenance_response }
 
-      it 'should return the response content' do
-        subject.last.should == ['Ok']
+      it 'returns the response content' do
+        expect(subject.last).to eq ['Ok']
       end
     end
   end
@@ -50,17 +50,17 @@ describe Rack::MaintenanceMode do
   context 'with a custom mode check (if)' do
     context 'when the custom check returns truthie' do
       let(:options) { {:if => -> env { true }} }
-      it { should be_a_maintenance_response }
-      it { should contain_the_default_response }
+      it { is_expected.to be_a_maintenance_response }
+      it { is_expected.to contain_the_default_response }
     end
 
     context 'when the custom check returns false' do
       let(:options) { {:if => -> env { false }} }
 
-      it { should_not be_a_maintenance_response }
+      it { is_expected.to_not be_a_maintenance_response }
 
-      it 'should return the response content' do
-        subject.last.should == ['Ok']
+      it 'returns the response content' do
+        expect(subject.last).to eq ['Ok']
       end
     end
   end
@@ -73,16 +73,16 @@ describe Rack::MaintenanceMode do
     context 'with maintenance enabled' do
       before(:each) { ENV['MAINTENANCE'] = 'true' }
 
-      it 'should return the custom response' do
-        subject.last.should == ['Custom']
+      it 'returns the custom response' do
+        expect(subject.last).to eq ['Custom']
       end
     end
 
     context 'with maintenance disabled' do
       before(:each) { ENV['MAINTENANCE'] = 'false' }
 
-      it 'should return the original response' do
-        subject.last.should == ['Ok']
+      it 'returns the original response' do
+        expect(subject.last).to eq ['Ok']
       end
     end
   end


### PR DESCRIPTION
Constants are required for middleware instead of string references.

```
DEPRECATION WARNING: Passing strings or symbols to the middleware builder is deprecated, please change
them to actual class references. For example:

"Rack::MaintenanceMode::Middleware" => Rack::MaintenanceMode::Middleware
```

I think this is fairly backward-compatible assuming that Rack::MaintenanceMode::Middleware is loaded first.

I also updated the specs to avoid RSpec warnings.
